### PR TITLE
Deprecated: getEntityManagerForClass

### DIFF
--- a/Cookie/CookieLogger.php
+++ b/Cookie/CookieLogger.php
@@ -28,7 +28,7 @@ class CookieLogger
 
     public function __construct(RegistryInterface $registry, Request $request)
     {
-        $this->entityManager = $registry->getEntityManagerForClass(CookieConsentLog::class);
+        $this->entityManager = $registry->getManagerForClass(CookieConsentLog::class);
         $this->request       = $request;
     }
 

--- a/Tests/Cookie/CookieLoggerTest.php
+++ b/Tests/Cookie/CookieLoggerTest.php
@@ -37,7 +37,7 @@ class CookieLoggerTest extends TestCase
         $registry = $this->createMock(RegistryInterface::class);
         $registry
             ->expects($this->once())
-            ->method('getEntityManagerForClass')
+            ->method('getManagerForClass')
             ->with(CookieConsentLog::class)
             ->willReturn($this->entityManager);
 


### PR DESCRIPTION
  | User Deprecated: getEntityManagerForClass is deprecated since Symfony 2.1. Use getManagerForClass instead
-- | --