### PR TITLE
Production autoload fix

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+Tests/ export-ignore

--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,14 @@
     },
     "prefer-stable": true,
     "autoload": {
+        "exclude-from-classmap": ["/Tests/"],
         "psr-4": {
             "ConnectHolland\\CookieConsentBundle\\": ""
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "ConnectHolland\\CookieConsentBundle\\Tests\\": "/Tests"
         }
     },
     "config": {


### PR DESCRIPTION
We had an issue when deploying this package to production. 
The error:
 `
Fatal error: During class fetch: Uncaught ReflectionException: Class PHPUnit\Framework\TestCase not found in /builds/vendor/connectholland/cookie-consent-bundle/Tests/Controller/CookieConsentControllerTest.php:23`

This pr fixes to issues in this package. First test files should not be distributed so I added them to the ignore list of the git export. which is used by github to generate the zip file that is downloaded by composer. 

The second fix removes the test files from the default generated autoloader. We don't want to have any test code executed in production so the files should be removed and only added to the dev-autoloader. 

The latter allows us for now to use our own fork in composer to fix the issue above.