### PR TITLE
FIX: white margin after user has given consent

### DIFF
--- a/Resources/public/js/cookie_consent.js
+++ b/Resources/public/js/cookie_consent.js
@@ -37,6 +37,8 @@ document.addEventListener("DOMContentLoaded", function() {
                 xhr.open('POST', cookieConsentForm.action);
                 xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
                 xhr.send(serializeForm(cookieConsentForm, event.target));
+		// Clear all styles from body to prevent the white margin at the end of the page
+		document.getElementsByTagName("body")[0].style = null;
             }, false);
         });
     }

--- a/Resources/public/js/cookie_consent.js
+++ b/Resources/public/js/cookie_consent.js
@@ -38,7 +38,8 @@ document.addEventListener("DOMContentLoaded", function() {
                 xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
                 xhr.send(serializeForm(cookieConsentForm, event.target));
 		// Clear all styles from body to prevent the white margin at the end of the page
-		document.getElementsByTagName("body")[0].style = null;
+		document.body.style.marginBottom = null;
+		document.body.style.marginTop  = null;
             }, false);
         });
     }


### PR DESCRIPTION
This fix removes all styles after the user has given a consent to place or block cookies.


If this pull request is useful please ad the following label `hacktoberfest-accepted`


