### PR TITLE
Use private cache for response

### DIFF
--- a/Controller/CookieConsentController.php
+++ b/Controller/CookieConsentController.php
@@ -83,7 +83,7 @@ class CookieConsentController
     {
         $this->setLocale($request);
 
-        return new Response(
+        $response = new Response(
             $this->twigEnvironment->render('@CHCookieConsent/cookie_consent.html.twig', [
                 'form'       => $this->createCookieConsentForm()->createView(),
                 'theme'      => $this->cookieConsentTheme,
@@ -91,6 +91,11 @@ class CookieConsentController
                 'simplified' => $this->cookieConsentSimplified,
             ])
         );
+
+        // Cache in ESI should not be shared
+        $response->setPrivate();
+
+        return $response;
     }
 
     /**

--- a/Controller/CookieConsentController.php
+++ b/Controller/CookieConsentController.php
@@ -94,6 +94,7 @@ class CookieConsentController
 
         // Cache in ESI should not be shared
         $response->setPrivate();
+        $response->setMaxAge(0);
 
         return $response;
     }


### PR DESCRIPTION
Without this change some visitors will not see the consent banner due to how cache in ESI is handled.