### PR TITLE
Feature/add custom form action

### DIFF
--- a/Controller/CookieConsentController.php
+++ b/Controller/CookieConsentController.php
@@ -16,6 +16,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
 
@@ -37,6 +38,11 @@ class CookieConsentController
     private $cookieChecker;
 
     /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    /**
      * @var string
      */
     private $cookieConsentTheme;
@@ -56,22 +62,31 @@ class CookieConsentController
      */
     private $cookieConsentSimplified;
 
+    /**
+     * @var string|null
+     */
+    private $formAction;
+
     public function __construct(
         Environment $twigEnvironment,
         FormFactoryInterface $formFactory,
         CookieChecker $cookieChecker,
+        RouterInterface $router,
         string $cookieConsentTheme,
         string $cookieConsentPosition,
         TranslatorInterface $translator,
-        bool $cookieConsentSimplified = false
+        bool $cookieConsentSimplified = false,
+        string $formAction = null
     ) {
         $this->twigEnvironment         = $twigEnvironment;
         $this->formFactory             = $formFactory;
         $this->cookieChecker           = $cookieChecker;
+        $this->router                  = $router;
         $this->cookieConsentTheme      = $cookieConsentTheme;
         $this->cookieConsentPosition   = $cookieConsentPosition;
         $this->translator              = $translator;
         $this->cookieConsentSimplified = $cookieConsentSimplified;
+        $this->formAction              = $formAction;
     }
 
     /**
@@ -118,7 +133,19 @@ class CookieConsentController
      */
     protected function createCookieConsentForm(): FormInterface
     {
-        return $this->formFactory->create(CookieConsentType::class);
+        if ($this->formAction === null) {
+            $form = $this->formFactory->create(CookieConsentType::class);
+        } else {
+            $form = $this->formFactory->create(
+                CookieConsentType::class,
+                null,
+                [
+                    'action' => $this->router->generate($this->formAction),
+                ]
+            );
+        }
+
+        return $form;
     }
 
     /**

--- a/DependencyInjection/CHCookieConsentExtension.php
+++ b/DependencyInjection/CHCookieConsentExtension.php
@@ -29,6 +29,7 @@ class CHCookieConsentExtension extends Extension
         $container->setParameter('ch_cookie_consent.simplified', $config['simplified']);
         $container->setParameter('ch_cookie_consent.http_only', $config['http_only']);
         $container->setParameter('ch_cookie_consent.form_action', $config['form_action']);
+        $container->setParameter('ch_cookie_consent.csrf_protection', $config['csrf_protection']);
 
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yaml');

--- a/DependencyInjection/CHCookieConsentExtension.php
+++ b/DependencyInjection/CHCookieConsentExtension.php
@@ -28,6 +28,7 @@ class CHCookieConsentExtension extends Extension
         $container->setParameter('ch_cookie_consent.position', $config['position']);
         $container->setParameter('ch_cookie_consent.simplified', $config['simplified']);
         $container->setParameter('ch_cookie_consent.http_only', $config['http_only']);
+        $container->setParameter('ch_cookie_consent.form_action', $config['form_action']);
 
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yaml');

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -53,6 +53,9 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('form_action')
                     ->defaultNull()
                 ->end()
+                ->booleanNode('csrf_protection')
+                    ->defaultTrue()
+                ->end()
             ->end()
         ;
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -50,6 +50,9 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('http_only')
                     ->defaultTrue()
                 ->end()
+                ->scalarNode('form_action')
+                    ->defaultNull()
+                ->end()
             ->end()
         ;
 

--- a/Form/CookieConsentType.php
+++ b/Form/CookieConsentType.php
@@ -35,11 +35,21 @@ class CookieConsentType extends AbstractType
      */
     protected $cookieConsentSimplified;
 
-    public function __construct(CookieChecker $cookieChecker, array $cookieCategories, bool $cookieConsentSimplified = false)
-    {
+    /**
+     * @var bool
+     */
+    protected $csrfProtection;
+
+    public function __construct(
+        CookieChecker $cookieChecker,
+        array $cookieCategories,
+        bool $cookieConsentSimplified = false,
+        bool $csrfProtection = true
+    ) {
         $this->cookieChecker           = $cookieChecker;
         $this->cookieCategories        = $cookieCategories;
         $this->cookieConsentSimplified = $cookieConsentSimplified;
+        $this->csrfProtection          = $csrfProtection;
     }
 
     /**
@@ -84,6 +94,7 @@ class CookieConsentType extends AbstractType
     {
         $resolver->setDefaults([
             'translation_domain' => 'CHCookieConsentBundle',
+            'csrf_protection' => $this->csrfProtection,
         ]);
     }
 }

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ ch_cookie_consent:
     simplified: false # When set to true the user can only deny or accept all cookies at once
     http_only: true # Sets HttpOnly on cookies
     form_action: $routeName # When set, xhr-Requests will only be sent to this route. Take care of having the route available.
+    csrf_protection: true # The cookie consent form is csrf protected or not
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ ch_cookie_consent:
     position: 'top' # top, bottom
     simplified: false # When set to true the user can only deny or accept all cookies at once
     http_only: true # Sets HttpOnly on cookies
+    form_action: $routeName # When set, xhr-Requests will only be sent to this route. Take care of having the route available.
 ```
 
 ## Usage

--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -13,6 +13,7 @@ services:
             $cookieConsentSimplified: '%ch_cookie_consent.simplified%'
             $httpOnly: '%ch_cookie_consent.http_only%'
             $formAction: '%ch_cookie_consent.form_action%'
+            $csrfProtection: '%ch_cookie_consent.csrf_protection%'
 
     ConnectHolland\CookieConsentBundle\:
         resource: '../../'

--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -12,6 +12,7 @@ services:
             $cookieConsentPosition: '%ch_cookie_consent.position%'
             $cookieConsentSimplified: '%ch_cookie_consent.simplified%'
             $httpOnly: '%ch_cookie_consent.http_only%'
+            $formAction: '%ch_cookie_consent.form_action%'
 
     ConnectHolland\CookieConsentBundle\:
         resource: '../../'

--- a/Tests/Controller/CookieConsentControllerTest.php
+++ b/Tests/Controller/CookieConsentControllerTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
 
@@ -44,6 +45,11 @@ class CookieConsentControllerTest extends TestCase
     private $translator;
 
     /**
+     * @var MockObject
+     */
+    private $router;
+
+    /**
      * @var CookieConsentController
      */
     private $cookieConsentController;
@@ -54,7 +60,17 @@ class CookieConsentControllerTest extends TestCase
         $this->formFactory             = $this->createMock(FormFactoryInterface::class);
         $this->cookieChecker           = $this->createMock(CookieChecker::class);
         $this->translator              = $this->createMock(TranslatorInterface::class);
-        $this->cookieConsentController = new CookieConsentController($this->templating, $this->formFactory, $this->cookieChecker, 'dark', 'top', $this->translator, false);
+        $this->router                  = $this->createMock(RouterInterface::class);
+        $this->cookieConsentController = new CookieConsentController(
+            $this->templating,
+            $this->formFactory,
+            $this->cookieChecker,
+            $this->router,
+            'dark',
+            'top',
+            $this->translator,
+            false
+        );
     }
 
     public function testShow(): void


### PR DESCRIPTION
Hey guys,

I made a quick enhancement regarding the custom form action. Default behavior is that is posts the consent submit to the current url via HTTP-Post.

I made it configurable to any existing route. It's not super fancy but it fulfills my need (I want to have an explicit route that I can use seeing that I have a quite complex Caching-Setup in my project).

Another improvement would be to provide a dummy route by the bundle and send all requests there. My solution requires making the given route available in any kind of routing / controller.

I've also added the possibility to disable csrf-token for the actual consent form submit.

@main maintainers: To be honest, I think the tests (especially functional / controller tests) could be improved by working with the actual framework and actual (sub)requests and more or less without mocks. If you like I could make them more flexible once I find some time.

Thanks for the bundle!!
Best 
Simon